### PR TITLE
adding packages to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 altair==4.2.0
 anyio==3.6.2
+appnope==0.1.3
 argon2-cffi==21.3.0
 argon2-cffi-bindings==21.2.0
 astroid==2.12.12
@@ -8,7 +9,6 @@ attrs==22.1.0
 Babel==2.11.0
 backcall==0.2.0
 backoff==2.2.1
-backports.zoneinfo==0.2.1
 beautifulsoup4==4.11.1
 bleach==5.0.1
 blinker==1.5
@@ -24,11 +24,14 @@ debugpy==1.6.3
 decorator==5.1.1
 defusedxml==0.7.1
 dill==0.3.6
+docopt==0.6.2
 entrypoints==0.4
 et-xmlfile==1.1.0
 executing==1.2.0
+extra-streamlit-components==0.1.56
 fastjsonschema==2.16.2
 filelock==3.8.0
+finnhub-python==2.4.15
 fonttools==4.38.0
 gitdb==4.0.9
 GitPython==3.1.29
@@ -63,6 +66,7 @@ nbclient==0.7.0
 nbconvert==7.2.3
 nbformat==5.7.0
 nest-asyncio==1.5.6
+nltk==3.7
 notebook==6.5.2
 notebook_shim==0.2.2
 numpy==1.23.4
@@ -76,6 +80,7 @@ parso==0.8.3
 pexpect==4.8.0
 pickleshare==0.7.5
 Pillow==9.3.0
+pipreqs==0.4.11
 pkgutil_resolve_name==1.3.10
 platformdirs==2.5.3
 plotly==5.11.0
@@ -112,6 +117,9 @@ sniffio==1.3.0
 soupsieve==2.3.2.post1
 stack-data==0.6.0
 streamlit==1.14.0
+streamlit-elements==0.1.0
+streamlit-option-menu==0.3.2
+streamlit-toggle-switch==1.0.2
 tenacity==8.1.0
 terminado==0.17.0
 threadpoolctl==3.1.0
@@ -136,5 +144,5 @@ wcwidth==0.2.5
 webencodings==0.5.1
 websocket-client==1.4.2
 wrapt==1.14.1
+yarg==0.1.9
 zipp==3.10.0
-nltk==3.7


### PR DESCRIPTION
backports.zoneinfo causes errors with python > v3.9, so editing that part of the requirements.txt file and adding more required packages.